### PR TITLE
Add nvme manager support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,24 @@
+ACLOCAL_AMFLAGS = -I m4
+AM_DEFAULT_SOURCE_EXT = .cpp
+bin_PROGRAMS = nvme_main
+
+nvme_main_SOURCES = \
+                nvme_main.cpp  \
+                nvme_manager.cpp \
+                smbus.cpp \
+                nvmes.cpp
+
+
+nvme_main_LDFLAGS = \
+                    -lstdc++fs \
+                    $(SDBUSPLUS_LIBS) \
+                    $(PHOSPHOR_DBUS_INTERFACES_LIBS) \
+                    $(SDEVENTPLUS_LIBS)
+
+nvme_main_CXX_FLAGS =  \
+                $(PHOSPHOR_DBUS_INTERFACES_CFLAGS) \
+	            $(SDBUSPLUS_CFLAGS) \
+	            $(PHOSPHOR_LOGGING_CFLAGS)
+
+nvmedir = $(sysconfdir)/nvme
+nvme_DATA = nvme_config.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,156 @@
+### phosphor-nvme
+
+#### Introduction
+
+phosphor-nvme is the nvme manager service maintains for NVMe drive information
+update and related notification processing service. The service update
+information to `xyz/openbmc_project/Nvme/Status.interface.yaml`,
+`xyz/openbmc_project/Sensor/Value.interface.yaml` and
+other interfaces in `xyz.openbmc_project.Inventory.Manager`.
+
+#### General usage
+
+The service `xyz.openbmc_project.nvme.manager` provides object on D-Bus:
+
+* /xyz/openbmc_project/sensors/temperature/nvme(index)
+
+where object implements interface `xyz.openbmc_project.Sensor.Value`.
+
+NVMe drive export as sensor and sensor value is temperature of drive.
+It can get the sensor value of the drive through ipmitool command `sdr elist`
+if the corresponding settings in the sensor map are configured correctly.
+For example:
+
+* To get sensor value:
+
+   ```
+   ### With ipmi command on BMC
+   ipmitool sdr elist
+   ```
+
+The service also updates other NVMe drive information to D-bus
+`xyz.openbmc_project.Inventory.Manager`. The service
+`xyz.openbmc_project.Inventory.Manager` provides object on D-Bus:
+
+* /xyz/openbmc_project/inventory/system/chassis/motherboard/nvme(index)
+
+where object implements interfaces:
+
+* xyz.openbmc_project.Inventory.Item
+* xyz.openbmc_project.Inventory.Decorator.Asset
+* xyz.openbmc_project.Nvme.Status
+
+Interface `xyz.openbmc_project.Nvme.Status` with the following properties:
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| SmartWarnings| string | Indicates smart warnings for the state |
+| StatusFlags | string | Indicates the status of the drives |
+| DriveLifeUsed | string | A vendor specific estimate of the percentage |
+| TemperatureFault| bool | If warning type about temperature happened |
+| BackupdrivesFault | bool | If warning type about backup drives happened |
+| CapacityFault| bool | If warning type about capacity happened |
+| DegradesFault| bool | If warning type about degrades happened |
+| MediaFault| bool | If warning type about media happened |
+
+Interface `xyz.openbmc_project.Inventory.Item` with the following properties:
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| Present | bool | Whether or not the item is present |
+
+Interface `xyz.openbmc_project.Inventory.Decorator.Asset` with the following
+properties:
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| SerialNumber | string | The item serial number |
+| Manufacturer | string | The item manufacturer |
+
+Each property in the inventory manager can be obtained via the busctl
+get-property command. For example:
+
+* To get property Present:
+
+   ```
+   ### With busctl on BMC
+   busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/nvme0 xyz.openbmc_project.Inventory.Item Present
+   ```
+
+#### Configuration file
+
+There is a JSON configuration file `nvme_config.json` for drive index, bus ID,
+and the LED object path and bus name for each drive.
+For example,
+
+```json
+{
+    "config": [
+        {
+            "NvmeDriveIndex": 0,
+            "NVMeDriveBusID": 16,
+            "NVMeDriveFaultLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_0_fault",
+            "NVMeDriveLocateLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_0_locate",
+            "NVMeDriveLocateLEDControllerBusName":"xyz.openbmc_project.LED.Controller.led_u2_0_locate",
+            "NVMeDriveLocateLEDControllerPath":"/xyz/openbmc_project/led/physical/led_u2_0_locate",
+            "NVMeDrivePresentPin": 148,
+            "NVMeDrivePwrGoodPin": 161
+        },
+        {
+            "NvmeDriveIndex": 1,
+            "NVMeDriveBusID": 17,
+            "NVMeDriveFaultLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_1_fault",
+            "NVMeDriveLocateLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_1_locate",
+            "NVMeDriveLocateLEDControllerBusName":"xyz.openbmc_project.LED.Controller.led_u2_1_locate",
+            "NVMeDriveLocateLEDControllerPath":"/xyz/openbmc_project/led/physical/led_u2_1_locate",
+            "NVMeDrivePresentPin": 149,
+            "NVMeDrivePwrGoodPin": 162
+        }
+    ],
+    "threshold":[
+        {
+            "criticalHigh":70,
+            "criticalLow":0,
+            "maxValue":70,
+            "minValue":0
+        }
+    ]
+}
+```
+
+* config
+  * NvmeDriveIndex: The index of the NVMe drive, which will be displayed in the
+                    object path.
+  * NVMeDriveBusID: The bus id of the NVMe drive, since it communicates with SMBus.
+  * NVMeDriveFaultLEDGroupPath: Object path of fault LED  in LED Group Manager.
+  * NVMeDriveLocateLEDGroupPath: Object path of locate LED  in LED Group Manager.
+  * NVMeDriveLocateLEDControllerBusName: D-Bus name of locate LED in LED Controller.
+  * NVMeDriveLocateLEDControllerPath: Object path of locate LED in LED Controller.
+  * NVMeDrivePresentPin: Gpio present pin of NVMe drive.
+  * NVMeDrivePwrGoodPin: Gpio Power good pin of NVMe drive.
+* threshold
+  * criticalHigh: Upper critical threshold.
+  * criticalLow: Lower critical threshold.
+  * maxValue: Sensor maximum value.
+  * minValue: Sensor value.
+
+#### Process
+
+1. It will register a D-bus called `xyz.openbmc_project.nvme.manager`
+   description above.
+2. Obtain the drive index, bus ID, GPIO present pin, power good pin and fault
+   LED object path from the json file mentioned above.
+3. Each cycle will do following steps:
+   1. Check if the present pin of target drive is true, if true, means drive
+      exists and go to next step. If not, means drive does not exists and
+      remove object path from D-bus by drive index.
+   2. Check if the power good pin of target drive is true, if true means drive
+      is ready then create object path by drive index and go to next step. If
+      not, means drive power abnormal, turn on fault LED and log in journal.
+   3. Send a NVMe-MI command via SMBus Block Read protocol by bus ID of target
+      drive to get data. Data get from NVMe drives are "Status Flags",
+      "SMART Warnings", "Temperature", "Percentage Drive Life Used",
+      "Vendor ID", and "Serial Number".
+   4. The data will be set to the properties in D-bus.
+
+This service will run automatically and look up NVMe drives every second.

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,96 @@
+# Initialization
+AC_PREREQ([2.69])
+AC_INIT([phosphor-nvme], [0.1])
+AC_LANG([C++])
+AC_CONFIG_HEADERS([config.h])
+AM_INIT_AUTOMAKE([subdir-objects -Wall foreign dist-xz])
+AM_SILENT_RULES([yes])
+
+# Checks for programs.
+AC_PROG_CXX
+AM_PROG_AR
+AC_PROG_INSTALL
+AC_PROG_MAKE_SET
+
+# Checks compiler characteristics.
+AX_CXX_COMPILE_STDCXX_17([noext])
+AX_APPEND_COMPILE_FLAGS([-Wall -Wno-unused-variable], [CXXFLAGS])
+
+# Checks for modules
+PKG_CHECK_MODULES([SDBUSPLUS], [sdbusplus],, [AC_MSG_ERROR([Could not find sdbusplus...openbmc/sdbusplus package required])])
+PKG_CHECK_MODULES([PHOSPHOR_LOGGING], [phosphor-logging],, [AC_MSG_ERROR([Could not find phosphor-logging...openbmc/phosphor-logging package required])])
+PKG_CHECK_MODULES([PHOSPHOR_DBUS_INTERFACES], [phosphor-dbus-interfaces],, [AC_MSG_ERROR([Could not find phosphor-dbus-interfaces...openbmc/phosphor-dbus-interfaces package required])])
+PKG_CHECK_MODULES([SDEVENTPLUS], [sdeventplus], [], [AC_MSG_ERROR(["sdeventplus required and not found."])])
+
+# Dbus service name
+AC_ARG_VAR(NVME_REQUEST_NAME, [The Dbus busname to own])
+AS_IF([test "x$NVME_REQUEST_NAME" == "x"], [NVME_REQUEST_NAME="xyz.openbmc_project.nvme.manager"])
+AC_DEFINE_UNQUOTED([NVME_REQUEST_NAME], ["$NVME_REQUEST_NAME"], [The Dbus busname to own])
+
+# Service dbus root
+AC_ARG_VAR(NVME_OBJ_PATH_ROOT, [The nvme Dbus root])
+AS_IF([test "x$NVME_OBJ_PATH_ROOT" == "x"], [NVME_OBJ_PATH_ROOT="/xyz/openbmc_project/sensors/temperature"])
+AC_DEFINE_UNQUOTED([NVME_OBJ_PATH_ROOT], ["$NVME_OBJ_PATH_ROOT"], [The nvme Dbus root])
+
+# Service dbus objpath
+AC_ARG_VAR(NVME_OBJ_PATH, [The nvme object path])
+AS_IF([test "x$NVME_OBJ_PATH" == "x"], [NVME_OBJ_PATH="/xyz/openbmc_project/sensors/temperature/nvme"])
+AC_DEFINE_UNQUOTED([NVME_OBJ_PATH], ["$NVME_OBJ_PATH"], [The nvme Dbus root])
+
+# Service dbus interface
+AC_ARG_VAR(DBUS_PROPERTY_IFACE, [The properies interface])
+AS_IF([test "x$DBUS_PROPERTY_IFACE" == "x"], [DBUS_PROPERTY_IFACE="org.freedesktop.DBus.Properties"])
+AC_DEFINE_UNQUOTED([DBUS_PROPERTY_IFACE], ["$DBUS_PROPERTY_IFACE"], [The nvme Dbus root])
+
+# LED group service dbus busname
+AC_ARG_VAR(LED_GROUP_BUSNAME, [The LED group manager dbus name])
+AS_IF([test "x$LED_GROUP_BUSNAME" == "x"], [LED_GROUP_BUSNAME="xyz.openbmc_project.LED.GroupManager"])
+AC_DEFINE_UNQUOTED([LED_GROUP_BUSNAME], ["$LED_GROUP_BUSNAME"], [The LED group manager dbus name])
+
+# LED group interface
+AC_ARG_VAR(LED_GROUP_IFACE, [The LED group manager interface])
+AS_IF([test "x$LED_GROUP_IFACE" == "x"], [LED_GROUP_IFACE="xyz.openbmc_project.Led.Group"])
+AC_DEFINE_UNQUOTED([LED_GROUP_IFACE], ["$LED_GROUP_IFACE"], [The LED group manager interface])
+
+# LED controller interface
+AC_ARG_VAR(LED_CONTROLLER_IFACE, [The LED controller interface])
+AS_IF([test "x$LED_CONTROLLER_IFACE" == "x"], [LED_CONTROLLER_IFACE="xyz.openbmc_project.Led.Physical"])
+AC_DEFINE_UNQUOTED([LED_CONTROLLER_IFACE], ["$LED_CONTROLLER_IFACE"], [The LED controller interface])
+
+# item interface
+AC_ARG_VAR(ITEM_IFACE, [The item interface])
+AS_IF([test "x$ITEM_IFACE" == "x"], [ITEM_IFACE="xyz.openbmc_project.Inventory.Item"])
+AC_DEFINE_UNQUOTED([ITEM_IFACE], ["$ITEM_IFACE"], [The item interface])
+
+# NVMe status interface
+AC_ARG_VAR(NVME_STATUS_IFACE, [The NVMe status interface])
+AS_IF([test "x$NVME_STATUS_IFACE" == "x"], [NVME_STATUS_IFACE="xyz.openbmc_project.Nvme.Status"])
+AC_DEFINE_UNQUOTED([NVME_STATUS_IFACE], ["$NVME_STATUS_IFACE"], [The NVMe status interface])
+
+# Asset interface
+AC_ARG_VAR(ASSET_IFACE, [The Asset interface])
+AS_IF([test "x$ASSET_IFACE" == "x"], [ASSET_IFACE="xyz.openbmc_project.Inventory.Decorator.Asset"])
+AC_DEFINE_UNQUOTED([ASSET_IFACE], ["$ASSET_IFACE"], [The Asset interface])
+
+# Inventory dbus busname
+AC_ARG_VAR(INVENTORY_BUSNAME, [The inventory busname])
+AS_IF([test "x$INVENTORY_BUSNAME" == "x"], [INVENTORY_BUSNAME="xyz.openbmc_project.Inventory.Manager"])
+AC_DEFINE_UNQUOTED([INVENTORY_BUSNAME], ["$INVENTORY_BUSNAME"], [The inventory busname])
+
+# Inventory path
+AC_ARG_VAR(INVENTORY_PATH, [The inventory path])
+AS_IF([test "x$INVENTORY_PATH" == "x"], [INVENTORY_PATH="/xyz/openbmc_project/inventory/system/chassis/motherboard/nvme"])
+AC_DEFINE_UNQUOTED([INVENTORY_PATH], ["$INVENTORY_PATH"], [The inventory path])
+
+LT_INIT # Required for systemd linking
+
+# Create configured output
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT
+
+
+
+
+
+
+

--- a/i2c-dev.h
+++ b/i2c-dev.h
@@ -1,0 +1,453 @@
+/*
+    i2c-dev.h - i2c-bus driver, char device interface
+
+    Copyright (C) 1995-97 Simon G. Vogl
+    Copyright (C) 1998-99 Frodo Looijaard <frodol@dds.nl>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA 02110-1301 USA.
+*/
+
+
+#ifndef _LINUX_I2C_DEV_H
+#define _LINUX_I2C_DEV_H
+
+#include <linux/types.h>
+#include <sys/ioctl.h>
+#include <stddef.h>
+
+
+/* -- i2c.h -- */
+
+
+/*
+ * I2C Message - used for pure i2c transaction, also from /dev interface
+ */
+struct i2c_msg {
+	__u16 addr;	/* slave address			*/
+	unsigned short flags;
+#define I2C_M_TEN	0x10	/* we have a ten bit chip address	*/
+#define I2C_M_RD		0x0001	/* read data, from slave to master */
+#define I2C_M_RECV_LEN		0x0400	/* length will be first received byte */
+#define I2C_M_NOSTART	0x4000
+#define I2C_M_REV_DIR_ADDR	0x2000
+#define I2C_M_IGNORE_NAK	0x1000
+#define I2C_M_NO_RD_ACK		0x0800
+	short len;		/* msg length				*/
+	char *buf;		/* pointer to msg data			*/
+};
+
+/* To determine what functionality is present */
+
+#define I2C_FUNC_I2C			0x00000001
+#define I2C_FUNC_10BIT_ADDR		0x00000002
+#define I2C_FUNC_PROTOCOL_MANGLING	0x00000004 /* I2C_M_{REV_DIR_ADDR,NOSTART,..} */
+#define I2C_FUNC_SMBUS_PEC		0x00000008
+#define I2C_FUNC_SMBUS_BLOCK_PROC_CALL	0x00008000 /* SMBus 2.0 */
+#define I2C_FUNC_SMBUS_QUICK		0x00010000
+#define I2C_FUNC_SMBUS_READ_BYTE	0x00020000
+#define I2C_FUNC_SMBUS_WRITE_BYTE	0x00040000
+#define I2C_FUNC_SMBUS_READ_BYTE_DATA	0x00080000
+#define I2C_FUNC_SMBUS_WRITE_BYTE_DATA	0x00100000
+#define I2C_FUNC_SMBUS_READ_WORD_DATA	0x00200000
+#define I2C_FUNC_SMBUS_WRITE_WORD_DATA	0x00400000
+#define I2C_FUNC_SMBUS_PROC_CALL	0x00800000
+#define I2C_FUNC_SMBUS_READ_BLOCK_DATA	0x01000000
+#define I2C_FUNC_SMBUS_WRITE_BLOCK_DATA 0x02000000
+#define I2C_FUNC_SMBUS_READ_I2C_BLOCK	0x04000000 /* I2C-like block xfer  */
+#define I2C_FUNC_SMBUS_WRITE_I2C_BLOCK	0x08000000 /* w/ 1-byte reg. addr. */
+
+#define I2C_FUNC_SMBUS_BYTE (I2C_FUNC_SMBUS_READ_BYTE | \
+                             I2C_FUNC_SMBUS_WRITE_BYTE)
+#define I2C_FUNC_SMBUS_BYTE_DATA (I2C_FUNC_SMBUS_READ_BYTE_DATA | \
+                                  I2C_FUNC_SMBUS_WRITE_BYTE_DATA)
+#define I2C_FUNC_SMBUS_WORD_DATA (I2C_FUNC_SMBUS_READ_WORD_DATA | \
+                                  I2C_FUNC_SMBUS_WRITE_WORD_DATA)
+#define I2C_FUNC_SMBUS_BLOCK_DATA (I2C_FUNC_SMBUS_READ_BLOCK_DATA | \
+                                   I2C_FUNC_SMBUS_WRITE_BLOCK_DATA)
+#define I2C_FUNC_SMBUS_I2C_BLOCK (I2C_FUNC_SMBUS_READ_I2C_BLOCK | \
+                                  I2C_FUNC_SMBUS_WRITE_I2C_BLOCK)
+
+/* Old name, for compatibility */
+#define I2C_FUNC_SMBUS_HWPEC_CALC	I2C_FUNC_SMBUS_PEC
+
+/*
+ * Data for SMBus Messages
+ */
+#define I2C_SMBUS_BLOCK_MAX	32	/* As specified in SMBus standard */
+#define I2C_DATA_MAX	256	
+#define I2C_SMBUS_I2C_BLOCK_MAX	32	/* Not specified but we use same structure */
+union i2c_smbus_data {
+	__u8 byte;
+	__u16 word;
+	__u8 block[I2C_SMBUS_BLOCK_MAX + 2]; /* block[0] is used for length */
+	                                            /* and one more for PEC */
+};
+
+/* smbus_access read or write markers */
+#define I2C_SMBUS_READ	1
+#define I2C_SMBUS_WRITE	0
+
+/* SMBus transaction types (size parameter in the above functions)
+   Note: these no longer correspond to the (arbitrary) PIIX4 internal codes! */
+#define I2C_SMBUS_QUICK		    0
+#define I2C_SMBUS_BYTE		    1
+#define I2C_SMBUS_BYTE_DATA	    2
+#define I2C_SMBUS_WORD_DATA	    3
+#define I2C_SMBUS_PROC_CALL	    4
+#define I2C_SMBUS_BLOCK_DATA	    5
+#define I2C_SMBUS_I2C_BLOCK_BROKEN  6
+#define I2C_SMBUS_BLOCK_PROC_CALL   7		/* SMBus 2.0 */
+#define I2C_SMBUS_I2C_BLOCK_DATA    8
+
+
+/* /dev/i2c-X ioctl commands.  The ioctl's parameter is always an
+ * unsigned long, except for:
+ *	- I2C_FUNCS, takes pointer to an unsigned long
+ *	- I2C_RDWR, takes pointer to struct i2c_rdwr_ioctl_data
+ *	- I2C_SMBUS, takes pointer to struct i2c_smbus_ioctl_data
+ */
+#define I2C_RETRIES	0x0701	/* number of times a device address should
+				   be polled when not acknowledging */
+#define I2C_TIMEOUT	0x0702	/* set timeout in units of 10 ms */
+
+/* NOTE: Slave address is 7 or 10 bits, but 10-bit addresses
+ * are NOT supported! (due to code brokenness)
+ */
+#define I2C_SLAVE	0x0703	/* Use this slave address */
+#define I2C_SLAVE_FORCE	0x0706	/* Use this slave address, even if it
+				   is already in use by a driver! */
+#define I2C_TENBIT	0x0704	/* 0 for 7 bit addrs, != 0 for 10 bit */
+
+#define I2C_FUNCS	0x0705	/* Get the adapter functionality mask */
+
+#define I2C_RDWR	0x0707	/* Combined R/W transfer (one STOP only) */
+
+#define I2C_PEC		0x0708	/* != 0 to use PEC with SMBus */
+#define I2C_SMBUS	0x0720	/* SMBus transfer */
+
+
+/* This is the structure as used in the I2C_SMBUS ioctl call */
+struct i2c_smbus_ioctl_data {
+	__u8 read_write;
+	__u8 command;
+	__u32 size;
+	union i2c_smbus_data *data;
+};
+
+/* This is the structure as used in the I2C_RDWR ioctl call */
+struct i2c_rdwr_ioctl_data {
+	struct i2c_msg *msgs;	/* pointers to i2c_msgs */
+	__u32 nmsgs;			/* number of i2c_msgs */
+};
+
+#define  I2C_RDRW_IOCTL_MAX_MSGS	42
+
+
+
+static inline __u8 i2c_8bit_addr_from_msg(const struct i2c_msg *msg)
+{
+	return (msg->addr << 1) | (msg->flags & I2C_M_RD ? 1 : 0);
+}
+
+/* Since I2C_M_RD not implement PEC in the linux driver layer, 
+   so copy some driver PEC check functions here */
+#define POLY    (0x1070U << 3)
+static inline __u8 crc8(__u16 data)
+{
+	int i;
+	
+	for (i = 0; i < 8; i++) {
+		if (data & 0x8000)
+			data = data ^ POLY;
+		data = data << 1;
+	}
+	return (__u8)(data >> 8);
+}
+
+/* Incremental CRC8 over count bytes in the array pointed to by p */
+static inline __u8 i2c_smbus_pec(__u8 crc, __u8 *p, size_t count)
+{
+	int i;
+
+	for (i = 0; i < (int)count; i++)
+		crc = crc8((crc ^ p[i]) << 8);
+	return crc;
+}
+
+/* Assume a 7-bit address, which is reasonable for SMBus */
+static inline __u8 i2c_smbus_msg_pec(__u8 pec, struct i2c_msg *msg)
+{
+	/* The address will be sent first */
+	__u8 addr = i2c_8bit_addr_from_msg(msg);
+	pec = i2c_smbus_pec(pec, &addr, 1);
+
+	/* The data buffer follows */
+	return i2c_smbus_pec(pec, (__u8 *)msg->buf, msg->len);
+}
+
+
+/* Return <0 on CRC error
+   If there was a write before this read (most cases) we need to take the
+   partial CRC from the write part into account.
+   Note that this function does modify the message (we need to decrease the
+   message length to hide the CRC byte from the caller). */
+static inline int i2c_smbus_check_pec(__u8 cpec, struct i2c_msg *msg)
+{
+	__u8 rpec = msg->buf[--msg->len];
+	cpec = i2c_smbus_msg_pec(cpec, msg);
+	if (rpec != cpec) {
+		printf("Error: Bad PEC 0x%02x vs. 0x%02x\n",
+			rpec, cpec);
+		return -1;
+	}
+	return 0;
+}
+
+static inline __s32 i2c_smbus_access(int file, char read_write, __u8 command,
+                                     int size, union i2c_smbus_data *data)
+{
+	struct i2c_smbus_ioctl_data args;
+
+	args.read_write = read_write;
+	args.command = command;
+	args.size = size;
+	args.data = data;
+	return ioctl(file,I2C_SMBUS,&args);
+}
+
+
+static inline __s32 i2c_smbus_write_quick(int file, __u8 value)
+{
+	return i2c_smbus_access(file,value,0,I2C_SMBUS_QUICK,NULL);
+}
+
+static inline __s32 i2c_smbus_read_byte(int file)
+{
+	union i2c_smbus_data data;
+	if (i2c_smbus_access(file,I2C_SMBUS_READ,0,I2C_SMBUS_BYTE,&data))
+		return -1;
+	else
+		return 0x0FF & data.byte;
+}
+
+static inline __s32 i2c_smbus_write_byte(int file, __u8 value)
+{
+	return i2c_smbus_access(file,I2C_SMBUS_WRITE,value,
+	                        I2C_SMBUS_BYTE,NULL);
+}
+
+static inline __s32 i2c_smbus_read_byte_data(int file, __u8 command)
+{
+	union i2c_smbus_data data;
+	if (i2c_smbus_access(file,I2C_SMBUS_READ,command,
+	                     I2C_SMBUS_BYTE_DATA,&data))
+		return -1;
+	else
+		return 0x0FF & data.byte;
+}
+
+static inline __s32 i2c_smbus_write_byte_data(int file, __u8 command,
+                                              __u8 value)
+{
+	union i2c_smbus_data data;
+	data.byte = value;
+	return i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                        I2C_SMBUS_BYTE_DATA, &data);
+}
+
+static inline __s32 i2c_smbus_read_word_data(int file, __u8 command)
+{
+	union i2c_smbus_data data;
+	if (i2c_smbus_access(file,I2C_SMBUS_READ,command,
+	                     I2C_SMBUS_WORD_DATA,&data))
+		return -1;
+	else
+		return 0x0FFFF & data.word;
+}
+
+static inline __s32 i2c_smbus_write_word_data(int file, __u8 command,
+                                              __u16 value)
+{
+	union i2c_smbus_data data;
+	data.word = value;
+	return i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                        I2C_SMBUS_WORD_DATA, &data);
+}
+
+static inline __s32 i2c_smbus_process_call(int file, __u8 command, __u16 value)
+{
+	union i2c_smbus_data data;
+	data.word = value;
+	if (i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                     I2C_SMBUS_PROC_CALL,&data))
+		return -1;
+	else
+		return 0x0FFFF & data.word;
+}
+
+
+/* Returns the number of read bytes */
+static inline __s32 i2c_smbus_read_block_data(int file, __u8 command,
+                                              __u8 *values)
+{
+	union i2c_smbus_data data;
+	int i;
+	if (i2c_smbus_access(file,I2C_SMBUS_READ,command,
+	                     I2C_SMBUS_BLOCK_DATA,&data))
+		return -1;
+	else {
+		for (i = 1; i <= data.block[0]; i++)
+			values[i-1] = data.block[i];
+		return data.block[0];
+	}
+}
+
+static inline __s32 i2c_smbus_write_block_data(int file, __u8 command,
+                                               __u8 length, const __u8 *values)
+{
+	union i2c_smbus_data data;
+	int i;
+	if (length > 32)
+		length = 32;
+	for (i = 1; i <= length; i++)
+		data.block[i] = values[i-1];
+	data.block[0] = length;
+	return i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                        I2C_SMBUS_BLOCK_DATA, &data);
+}
+
+/* Returns the number of read bytes */
+/* Until kernel 2.6.22, the length is hardcoded to 32 bytes. If you
+   ask for less than 32 bytes, your code will only work with kernels
+   2.6.23 and later. */
+static inline __s32 i2c_smbus_read_i2c_block_data(int file, __u8 command,
+                                                  __u8 length, __u8 *values)
+{
+	union i2c_smbus_data data;
+	int i;
+
+	if (length > 32)
+		length = 32;
+	data.block[0] = length;
+	if (i2c_smbus_access(file,I2C_SMBUS_READ,command,
+	                     length == 32 ? I2C_SMBUS_I2C_BLOCK_BROKEN :
+	                      I2C_SMBUS_I2C_BLOCK_DATA,&data))
+		return -1;
+	else {
+		for (i = 1; i <= data.block[0]; i++)
+			values[i-1] = data.block[i];
+		return data.block[0];
+	}
+}
+
+static inline __s32 i2c_smbus_write_i2c_block_data(int file, __u8 command,
+                                                   __u8 length,
+                                                   const __u8 *values)
+{
+	union i2c_smbus_data data;
+	int i;
+	if (length > 32)
+		length = 32;
+	for (i = 1; i <= length; i++)
+		data.block[i] = values[i-1];
+	data.block[0] = length;
+	return i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                        I2C_SMBUS_I2C_BLOCK_BROKEN, &data);
+}
+
+static inline __s32 i2c_read_after_write(int file, __u8 command,
+												   __u8 slave_addr,
+                                                   __u8 tx_len,
+                                                   const __u8 *tx_buf,
+                                                   int rx_len,
+                                                   const __u8 *rx_buf)
+{
+	struct i2c_rdwr_ioctl_data msgst;
+	struct i2c_msg msg[2];
+	int ret;
+	int status;
+	__u8 partial_pec = 0;
+	
+	msg[0].addr = slave_addr & 0xFF;
+	msg[0].flags = 0;
+	msg[0].buf = (char *)tx_buf;
+	msg[0].len = tx_len;
+
+	msg[1].addr = slave_addr & 0xFF;
+	msg[1].flags = I2C_M_RD | I2C_M_RECV_LEN; 
+	msg[1].buf = (char *)rx_buf;
+	msg[1].len = rx_len;
+
+	msgst.msgs = msg;
+	msgst.nmsgs = 2;
+
+	ret = ioctl(file, I2C_RDWR, &msgst);
+	if(ret < 0)
+		return ret;
+	else if(command){
+		partial_pec = i2c_smbus_msg_pec(0, &msg[0]);
+		msg[1].len = rx_buf[0] + 1;
+		status = i2c_smbus_check_pec(partial_pec, &msg[1]);
+		return status;
+	}
+	return ret;
+}
+
+/* Returns the number of read bytes */
+static inline __s32 i2c_smbus_block_process_call(int file, __u8 command,
+                                                 __u8 length, __u8 *values)
+{
+	union i2c_smbus_data data;
+	int i;
+	if (length > 32)
+		length = 32;
+	for (i = 1; i <= length; i++)
+		data.block[i] = values[i-1];
+	data.block[0] = length;
+	if (i2c_smbus_access(file,I2C_SMBUS_WRITE,command,
+	                     I2C_SMBUS_BLOCK_PROC_CALL,&data))
+		return -1;
+	else {
+		for (i = 1; i <= data.block[0]; i++)
+			values[i-1] = data.block[i];
+		return data.block[0];
+	}
+}
+
+static inline __s32 i2c_master_write(int file, 	   __u8 slave_addr,
+                                                   __u8 tx_len,
+                                                   const __u8 *tx_buf)
+{
+	struct i2c_rdwr_ioctl_data msgst;
+	struct i2c_msg msg;
+	int ret;
+	int status;
+	__u8 partial_pec = 0;
+	
+	msg.addr = slave_addr & 0xFF;
+	msg.flags = 0;
+	msg.buf = (char *)tx_buf;
+	msg.len = tx_len;
+
+	msgst.msgs = &msg;
+	msgst.nmsgs = 1;
+
+	ret = ioctl(file, I2C_RDWR, &msgst);
+	
+	return ret;
+}
+
+#endif /* _LINUX_I2C_DEV_H */

--- a/nvme_config.json
+++ b/nvme_config.json
@@ -1,0 +1,92 @@
+{
+    "config": [
+        {
+            "NvmeDriveIndex": 0,
+            "NVMeDriveBusID": 16,
+            "NVMeDriveFaultLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_0_fault",
+            "NVMeDriveLocateLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_0_locate",
+            "NVMeDriveLocateLEDControllerBusName":"xyz.openbmc_project.LED.Controller.led_u2_0_locate",
+            "NVMeDriveLocateLEDControllerPath":"/xyz/openbmc_project/led/physical/led_u2_0_locate",
+            "NVMeDrivePresentPin": 148,
+            "NVMeDrivePwrGoodPin": 161
+        },
+        {
+            "NvmeDriveIndex": 1,
+            "NVMeDriveBusID": 17,
+            "NVMeDriveFaultLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_1_fault",
+            "NVMeDriveLocateLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_1_locate",
+            "NVMeDriveLocateLEDControllerBusName":"xyz.openbmc_project.LED.Controller.led_u2_1_locate",
+            "NVMeDriveLocateLEDControllerPath":"/xyz/openbmc_project/led/physical/led_u2_1_locate",
+            "NVMeDrivePresentPin": 149,
+            "NVMeDrivePwrGoodPin": 162
+        },
+        {
+            "NvmeDriveIndex": 2,
+            "NVMeDriveBusID": 18,
+            "NVMeDriveFaultLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_2_fault",
+            "NVMeDriveLocateLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_2_locate",
+            "NVMeDriveLocateLEDControllerBusName":"xyz.openbmc_project.LED.Controller.led_u2_2_locate",
+            "NVMeDriveLocateLEDControllerPath":"/xyz/openbmc_project/led/physical/led_u2_2_locate",
+            "NVMeDrivePresentPin": 150,
+            "NVMeDrivePwrGoodPin": 163
+        },
+        {
+            "NvmeDriveIndex": 3,
+            "NVMeDriveBusID": 19,
+            "NVMeDriveFaultLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_3_fault",
+            "NVMeDriveLocateLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_3_locate",
+            "NVMeDriveLocateLEDControllerBusName":"xyz.openbmc_project.LED.Controller.led_u2_3_locate",
+            "NVMeDriveLocateLEDControllerPath":"/xyz/openbmc_project/led/physical/led_u2_3_locate",
+            "NVMeDrivePresentPin": 151,
+            "NVMeDrivePwrGoodPin": 164
+        },
+        {
+            "NvmeDriveIndex": 4,
+            "NVMeDriveBusID": 20,
+            "NVMeDriveFaultLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_4_fault",
+            "NVMeDriveLocateLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_4_locate",
+            "NVMeDriveLocateLEDControllerBusName":"xyz.openbmc_project.LED.Controller.led_u2_4_locate",
+            "NVMeDriveLocateLEDControllerPath":"/xyz/openbmc_project/led/physical/led_u2_4_locate",
+            "NVMeDrivePresentPin": 152,
+            "NVMeDrivePwrGoodPin": 165
+        },
+        {
+            "NvmeDriveIndex": 5,
+            "NVMeDriveBusID": 21,
+            "NVMeDriveFaultLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_5_fault",
+            "NVMeDriveLocateLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_5_locate",
+            "NVMeDriveLocateLEDControllerBusName":"xyz.openbmc_project.LED.Controller.led_u2_5_locate",
+            "NVMeDriveLocateLEDControllerPath":"/xyz/openbmc_project/led/physical/led_u2_5_locate",
+            "NVMeDrivePresentPin": 153,
+            "NVMeDrivePwrGoodPin": 166
+        },
+        {
+            "NvmeDriveIndex": 6,
+            "NVMeDriveBusID": 22,
+            "NVMeDriveFaultLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_6_fault",
+            "NVMeDriveLocateLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_6_locate",
+            "NVMeDriveLocateLEDControllerBusName":"xyz.openbmc_project.LED.Controller.led_u2_6_locate",
+            "NVMeDriveLocateLEDControllerPath":"/xyz/openbmc_project/led/physical/led_u2_6_locate",
+            "NVMeDrivePresentPin": 154,
+            "NVMeDrivePwrGoodPin": 167
+        },
+        {
+            "NvmeDriveIndex": 7,
+            "NVMeDriveBusID": 23,
+            "NVMeDriveFaultLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_7_fault",
+            "NVMeDriveLocateLEDGroupPath": "/xyz/openbmc_project/led/groups/led_u2_7_locate",
+            "NVMeDriveLocateLEDControllerBusName":"xyz.openbmc_project.LED.Controller.led_u2_7_locate",
+            "NVMeDriveLocateLEDControllerPath":"/xyz/openbmc_project/led/physical/led_u2_7_locate",
+            "NVMeDrivePresentPin": 155,
+            "NVMeDrivePwrGoodPin": 168
+        }
+    ],
+    "threshold":[
+        {
+            "criticalHigh":70,
+            "criticalLow":0,
+            "maxValue":70,
+            "minValue":0
+        }
+    ]
+}

--- a/nvme_main.cpp
+++ b/nvme_main.cpp
@@ -1,0 +1,43 @@
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/sdbus.hpp>
+#include <sdbusplus/server/manager.hpp>
+#include <string.h>
+#include "nvme_manager.hpp"
+#include <set>
+#include <fstream>
+#include <phosphor-logging/log.hpp>
+#include <phosphor-logging/elog-errors.hpp>
+
+using namespace phosphor::logging;
+
+int main(void)
+{
+
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+
+    sd_event* event = nullptr;
+    auto eventDeleter = [](sd_event* e) { e = sd_event_unref(e); };
+    using SdEvent = std::unique_ptr<sd_event, decltype(eventDeleter)>;
+    // acquire a reference to the default event loop
+    sd_event_default(&event);
+    SdEvent sdEvent{event, eventDeleter};
+    event = nullptr;
+    // attach bus to this event loop
+    bus.attach_event(sdEvent.get(), SD_EVENT_PRIORITY_NORMAL);
+
+    sdbusplus::server::manager::manager objManager(bus, NVME_OBJ_PATH_ROOT);
+
+    phosphor::nvme::Nvme objMgr(bus, NVME_OBJ_PATH_ROOT);
+
+    bus.request_name(NVME_REQUEST_NAME);
+
+    objMgr.run();
+
+    // Start event loop for all sd-bus events
+
+    sd_event_loop(bus.get_event());
+
+    bus.detach_event();
+
+    return 0;
+}

--- a/nvme_manager.cpp
+++ b/nvme_manager.cpp
@@ -1,0 +1,571 @@
+#include "nvme_manager.hpp"
+#include "nlohmann/json.hpp"
+#include "smbus.hpp"
+#include <experimental/filesystem>
+#include <fstream>
+#include <iostream>
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/log.hpp>
+#include <sstream>
+#include <string>
+#include "i2c-dev.h"
+#include <xyz/openbmc_project/Led/Physical/server.hpp>
+
+#define MAX_I2C_BUS 30
+#define MONITOR_INTERVAL_SENCODS 1
+#define NVME_SSD_SLAVE_ADDRESS 0x6a
+#define GPIO_BASE_PATH "/sys/class/gpio/gpio"
+#define IS_PRESENT "0"
+#define POWERGD "1"
+
+static int fd[MAX_I2C_BUS] = {0};
+static constexpr auto configFile = "/etc/nvme/nvme_config.json";
+auto retries = 3;
+static constexpr auto delay = std::chrono::milliseconds{100};
+using Json = nlohmann::json;
+std::vector<phosphor::nvme::Nvme::NVMeConfig> configs;
+namespace fs = std::experimental::filesystem;
+
+namespace phosphor
+{
+namespace nvme
+{
+
+using namespace std;
+using namespace phosphor::logging;
+
+void Nvme::assertFaultLog(int smartWarning, std::string inventoryPath)
+{
+    bool bit;
+
+    for (int i = 0; i < 5; i++)
+    {
+        if (((smartWarning >> i) & 1) == 0)
+            bit = true;
+        else
+            bit = false;
+
+        switch (i)
+        {
+            case 0:
+                setInventoryParm(inventoryPath, NVME_STATUS_IFACE, "CapacityFault", bit);
+                break;
+            case 1:
+                setInventoryParm(inventoryPath, NVME_STATUS_IFACE, "TemperatureFault", bit);
+                break;
+            case 2:
+                setInventoryParm(inventoryPath, NVME_STATUS_IFACE, "DegradesFault", bit);
+                break;
+            case 3:
+                setInventoryParm(inventoryPath, NVME_STATUS_IFACE, "MediaFault", bit);
+                break;
+            case 4:
+                setInventoryParm(inventoryPath, NVME_STATUS_IFACE, "BackupDeviceFault", bit);
+                break;
+        }
+    }
+}
+
+void Nvme::setNvmeInventoryProperties(bool present, phosphor::nvme::Nvme::NVMeData nvmeData, std::string inventoryPath)
+{
+    setInventoryParm(inventoryPath, ITEM_IFACE, "Present", present);
+    setInventoryParm(inventoryPath, ASSET_IFACE, "Manufacturer", nvmeData.vendor);
+    setInventoryParm(inventoryPath, ASSET_IFACE, "SerialNumber", nvmeData.serialNumber);
+    setInventoryParm(inventoryPath, NVME_STATUS_IFACE, "SmartWarnings", nvmeData.smartWarnings);
+    setInventoryParm(inventoryPath, NVME_STATUS_IFACE, "StatusFlags", nvmeData.statusFlags);
+    setInventoryParm(inventoryPath, NVME_STATUS_IFACE, "DriveLifeUsed", nvmeData.driveLifeUsed);
+}
+
+template <typename T>
+void Nvme::setInventoryParm(std::string &objPath, const std::string &interface, const std::string &property, const T &value)
+{
+
+    sdbusplus::message::variant<T> data = value;
+
+    try{
+        auto methodCall = bus.new_method_call(INVENTORY_BUSNAME, objPath.c_str(),
+                                            DBUS_PROPERTY_IFACE, "Set");
+
+        methodCall.append(interface.c_str());
+        methodCall.append(property);
+        methodCall.append(data);
+
+        auto reply = bus.call(methodCall);
+
+    }catch (const std::exception &e)
+    {
+        std::cerr << "Call method fail: set inventory properties. ERROR = " << e.what() << std::endl;
+        std::cerr << "objPath = " << objPath << std::endl;
+        return ;
+    }
+}
+
+void Nvme::checkAssertFaultLED(std::string &locateLedGroupPath, std::string &faultLedGroupPath, bool request)
+{
+    if(locateLedGroupPath.empty() || faultLedGroupPath.empty())
+    {
+        return;
+    }
+
+    if( !getLEDGroupState(locateLedGroupPath)) // Before asserted LED, check whether is Identify or not.
+    {
+        setFaultLED("Asserted", request, faultLedGroupPath);
+    }
+}
+
+void Nvme::checkAssertLocateLED(std::string &locateLedGroupPath, std::string &locateLedBusName, std::string &locateLedPath , bool isPresent)
+{
+    if(locateLedGroupPath.empty() || locateLedBusName.empty() || locateLedPath.empty())
+    {
+        return;
+    }
+
+    namespace server = sdbusplus::xyz::openbmc_project::Led::server;
+
+    if( !getLEDGroupState(locateLedGroupPath))
+    {
+        if(isPresent)
+            setLocateLED("State", server::convertForMessage(server::Physical::Action::On), locateLedBusName, locateLedPath);
+        else
+            setLocateLED("State", server::convertForMessage(server::Physical::Action::Off), locateLedBusName, locateLedPath);
+    }
+
+}
+
+bool Nvme::getLEDGroupState(std::string &ledPath)
+{
+    std::string obj_path;
+    obj_path = ledPath;
+    bool asserted = false;
+
+    try{
+        auto method = bus.new_method_call(LED_GROUP_BUSNAME, obj_path.c_str(),
+                                      DBUS_PROPERTY_IFACE, "GetAll");
+
+        method.append(LED_GROUP_IFACE);
+        auto reply = bus.call(method);
+
+        std::map<std::string, variant<bool>> properties;
+        reply.read(properties);
+
+        asserted = get<bool>(properties.at("Asserted"));
+
+    }catch (const sdbusplus::exception::SdBusError& ex)
+    {
+        std::cerr << "Call method fail: Error in get LED group status. ERROR = " << ex.what() << std::endl;
+        std::cerr << "path = " << ledPath << std::endl;
+    }
+    return asserted;
+}
+
+template <typename T>
+void Nvme::setFaultLED(const std::string &property, const T &value, std::string &ledPath)
+{
+    if(ledPath.empty())
+        return;
+
+    sdbusplus::message::variant<bool> data = value;
+    std::string obj_path;
+    obj_path = ledPath;
+
+    try{
+        auto methodCall = bus.new_method_call(LED_GROUP_BUSNAME, obj_path.c_str(),
+                                            DBUS_PROPERTY_IFACE, "Set");
+
+        methodCall.append(LED_GROUP_IFACE);
+        methodCall.append(property);
+        methodCall.append(data);
+
+        auto reply = bus.call(methodCall);
+
+    }catch (const sdbusplus::exception::SdBusError& ex)
+    {
+        std::cerr << "Call method fail: set fault LED Aasserted. ERROR = " << ex.what() << std::endl;
+        std::cerr << "path = " << ledPath << std::endl;
+        return ;
+    }
+}
+
+template <typename T>
+void Nvme::setLocateLED(const std::string& property, const T& value, std::string &locateLedBusName, std::string &locateLedPath)
+{
+    sdbusplus::message::variant<T> data = value;
+    std::string obj_path;
+    obj_path = locateLedPath;
+
+    try{
+        auto methodCall = bus.new_method_call(locateLedBusName.c_str(), obj_path.c_str(),
+                                                DBUS_PROPERTY_IFACE, "Set");
+
+        methodCall.append(LED_CONTROLLER_IFACE);
+        methodCall.append(property);
+        methodCall.append(data);
+
+        auto reply = bus.call(methodCall);
+
+    }catch (const sdbusplus::exception::SdBusError& ex)
+    {
+        std::cerr << "Call method fail: set locate LED state. ERROR = " << ex.what() << std::endl;
+        std::cerr << "path = " << locateLedPath << std::endl;
+        return ;
+    }
+}
+
+std::string intToHex(int input)
+{
+    std::stringstream tmp;
+    tmp << std::hex << input;
+
+    return tmp.str();
+}
+
+bool getNVMeInfobyBusID(int busID, phosphor::nvme::Nvme::NVMeData &nvmeData)
+{
+    nvmeData.present = true;
+    nvmeData.vendor = "";
+    nvmeData.serialNumber = "";
+    nvmeData.smartWarnings = "";
+    nvmeData.statusFlags = "";
+    nvmeData.driveLifeUsed = "";
+    nvmeData.sensorValue = 129;
+
+    phosphor::smbus::Smbus smbus;
+
+    unsigned char rsp_data_command_0[8] = {0};
+    unsigned char rsp_data_command_8[24] = {0};
+
+    uint8_t in_data = 0; // command code
+
+    auto init = smbus.smbusInit(busID);
+
+    if (init == -1)
+    {
+        std::cerr << "smbusInit fail!" << std::endl;
+
+        nvmeData.present = false;
+
+        return nvmeData.present;
+    }
+
+    auto res_int = smbus.SendSmbusRWBlockCmdRAW(
+        busID, NVME_SSD_SLAVE_ADDRESS, &in_data, 1, rsp_data_command_0);
+
+    if (res_int < 0)
+    {
+        std::cerr << "Send command code 0 fail!" << std::endl;
+
+        smbus.smbusClose(busID);
+        nvmeData.present = false;
+        return nvmeData.present;
+    }
+
+    in_data = 8; // command code
+
+    res_int = smbus.SendSmbusRWBlockCmdRAW(busID, NVME_SSD_SLAVE_ADDRESS,
+                                           &in_data, 1, rsp_data_command_8);
+
+    if (res_int < 0)
+    {
+        std::cerr << "Send command code 8 fail!" << std::endl;
+        smbus.smbusClose(busID);
+        nvmeData.present = false;
+        return nvmeData.present;
+    }
+
+    nvmeData.vendor =
+        intToHex(rsp_data_command_8[1]) + " " + intToHex(rsp_data_command_8[2]);
+    for (int i = 3; i < 23; i++) // i: serialNumber position
+    {
+        nvmeData.serialNumber += static_cast<char>(rsp_data_command_8[i]);
+    }
+
+    nvmeData.statusFlags = intToHex(rsp_data_command_0[1]);
+    nvmeData.smartWarnings = intToHex(rsp_data_command_0[2]);
+    nvmeData.driveLifeUsed = intToHex(rsp_data_command_0[4]);
+    nvmeData.sensorValue = (u_int64_t)rsp_data_command_0[3];
+
+    smbus.smbusClose(busID);
+
+    return nvmeData.present;
+}
+
+void Nvme::run()
+{
+    init();
+
+    std::function<void()> callback(std::bind(&Nvme::read, this));
+    try
+    {
+        u_int64_t interval = MONITOR_INTERVAL_SENCODS * 1000000;
+        _timer.restart(std::chrono::microseconds(interval));
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "Error in polling loop. ERROR = " << e.what() << std::endl;
+    }
+}
+
+Json parseSensorConfig()
+{
+    std::ifstream jsonFile(configFile);
+    if (!jsonFile.is_open())
+    {
+        std::cerr << "NVMe config JSON file not found" << std::endl;
+    }
+
+    auto data = Json::parse(jsonFile, nullptr, false);
+    if (data.is_discarded())
+    {
+        std::cerr << "NVMe config readings JSON parser failure" << std::endl;
+    }
+
+    return data;
+}
+
+std::vector<phosphor::nvme::Nvme::NVMeConfig> getNvmeConfig()
+{
+
+    phosphor::nvme::Nvme::NVMeConfig nvmeConfig;
+    std::vector<phosphor::nvme::Nvme::NVMeConfig> nvmeConfigs;
+    uint64_t criticalHigh = 0;
+    uint64_t criticalLow = 0;
+    uint64_t maxValue = 0;
+    uint64_t minValue = 0;
+
+    try
+    {
+        auto data = parseSensorConfig();
+        static const std::vector<Json> empty{};
+        std::vector<Json> readings = data.value("config", empty);
+        std::vector<Json> thresholds = data.value("threshold", empty);
+        if (!thresholds.empty())
+        {
+            for (const auto &instance : thresholds)
+            {
+                criticalHigh = instance.value("criticalHigh", 0);
+                criticalLow = instance.value("criticalLow", 0);
+                maxValue = instance.value("maxValue", 0);
+                minValue = instance.value("minValue", 0);
+            }
+        }
+        else
+        {
+            std::cerr << "Invalid NVMe config file, thresholds dosen't exist" << std::endl;
+        }
+
+        if (!readings.empty())
+        {
+            for (const auto &instance : readings)
+            {
+                uint8_t index = instance.value("NvmeDriveIndex", 0);
+                uint8_t busID = instance.value("NVMeDriveBusID", 0);
+                std::string faultLedGroupPath =
+                    instance.value("NVMeDriveFaultLEDGroupPath", "");
+                std::string locateLedGroupPath =
+                    instance.value("NVMeDriveLocateLEDGroupPath", "");
+                uint8_t presentPin = instance.value("NVMeDrivePresentPin", 0);
+                uint8_t pwrGoodPin = instance.value("NVMeDrivePwrGoodPin", 0);
+                std::string locateLedControllerBusName =
+                    instance.value("NVMeDriveLocateLEDControllerBusName", "");
+                std::string locateLedControllerPath =
+                    instance.value("NVMeDriveLocateLEDControllerPath", "");
+
+                nvmeConfig.index = index;
+                nvmeConfig.busID = busID;
+                nvmeConfig.faultLedGroupPath = faultLedGroupPath;
+                nvmeConfig.presentPin = presentPin;
+                nvmeConfig.pwrGoodPin = pwrGoodPin;
+                nvmeConfig.locateLedControllerBusName =
+                    locateLedControllerBusName;
+                nvmeConfig.locateLedControllerPath = locateLedControllerPath;
+                nvmeConfig.locateLedGroupPath = locateLedGroupPath;
+                nvmeConfig.criticalHigh = criticalHigh;
+                nvmeConfig.criticalLow = criticalLow;
+                nvmeConfig.maxValue = maxValue;
+                nvmeConfig.minValue = minValue;
+                nvmeConfigs.push_back(nvmeConfig);
+            }
+        }
+        else
+        {
+            std::cerr << "Invalid NVMe config file, config dosen't exist" << std::endl;
+        }
+    }
+    catch (const Json::exception &e)
+    {
+        std::cerr << "Json Exception caught. MSG: " << e.what() << std::endl;
+    }
+
+    return nvmeConfigs;
+}
+
+std::string Nvme::getValue(std::string fullPath)
+{
+    std::string val;
+    std::ifstream ifs;
+
+    while (true)
+    {
+        try
+        {
+            if (!ifs.is_open())
+                ifs.open(fullPath);
+            ifs.clear();
+            ifs.seekg(0);
+            ifs >> val;
+        }
+        catch (const std::exception &e)
+        {
+            --retries;
+            std::this_thread::sleep_for(delay);
+            std::cerr << "Can not open gpio path MSG: " << e.what() << std::endl;
+            continue;
+        }
+        break;
+    }
+
+    ifs.close();
+    return val;
+}
+
+void Nvme::init()
+{
+    // read json file
+    configs = getNvmeConfig();
+}
+
+void Nvme::setSSDLEDStatus(std::shared_ptr<phosphor::nvme::NvmeSSD> nvmeSSD,
+                           phosphor::nvme::Nvme::NVMeConfig config,
+                           bool success,
+                           phosphor::nvme::Nvme::NVMeData nvmeData)
+{
+    if (success)
+    {
+        if (!nvmeData.smartWarnings.empty())
+        {
+            std::string inventoryPath = INVENTORY_PATH + std::to_string(config.index);
+            assertFaultLog(std::stoi(nvmeData.smartWarnings, 0, 16), inventoryPath);
+            auto request = (strcmp(nvmeData.smartWarnings.c_str(), "ff") == 0)
+                               ? false
+                               : true;
+            checkAssertFaultLED(config.locateLedGroupPath,
+                                    config.faultLedGroupPath, request);
+            checkAssertLocateLED(config.locateLedGroupPath,
+                                     config.locateLedControllerBusName,
+                                     config.locateLedControllerPath, !request);
+        }
+    }
+    else
+    {
+        // Drive is present but can not get data, turn on fault LED.
+        std::cerr << "Drive status is good but can not get data. index = " << std::to_string(config.index) << std::endl;
+        checkAssertFaultLED(config.locateLedGroupPath,
+                                config.faultLedGroupPath, true);
+        checkAssertLocateLED(config.locateLedGroupPath,
+                                 config.locateLedControllerBusName,
+                                 config.locateLedControllerPath, false);
+    }
+}
+
+
+
+void Nvme::read()
+{
+    std::string devPresentPath;
+    std::string devPwrGoodPath;
+    std::string inventoryPath;
+
+        for (int i = 0; i < configs.size(); i++)
+        {
+            NVMeData nvmeData;
+            devPresentPath =
+                GPIO_BASE_PATH + std::to_string(configs[i].presentPin) + "/value";
+
+            devPwrGoodPath =
+                GPIO_BASE_PATH + std::to_string(configs[i].pwrGoodPin) + "/value";
+
+            inventoryPath = INVENTORY_PATH + std::to_string(configs[i].index);
+
+            auto iter = nvmes.find(std::to_string(configs[i].index));
+
+            if (getValue(devPresentPath) == IS_PRESENT)
+            {
+                // Drive status is good, update value or create d-bus and update
+                // value.
+                if (getValue(devPwrGoodPath) == POWERGD)
+                {
+                    // get NVMe information through i2c by busID.
+                    auto success = getNVMeInfobyBusID(configs[i].busID, nvmeData);
+                    // can not find. create dbus
+                    if (iter == nvmes.end())
+                    {
+                        std::cerr << "SSD plug. index = "<< std::to_string(configs[i].index) << std::endl;
+
+                        std::string objPath =
+                            NVME_OBJ_PATH + std::to_string(configs[i].index);
+                        auto nvmeSSD = std::make_shared<phosphor::nvme::NvmeSSD>(
+                            bus, objPath.c_str());
+                        nvmes.emplace(std::to_string(configs[i].index), nvmeSSD);
+
+                        setNvmeInventoryProperties(true, nvmeData, inventoryPath);
+                        nvmeSSD->setSensorValueToDbus(nvmeData.sensorValue);
+                        nvmeSSD->setSensorThreshold(
+                            configs[i].criticalHigh, configs[i].criticalLow,
+                            configs[i].maxValue, configs[i].minValue);
+
+                        nvmeSSD->checkSensorThreshold();
+                        setSSDLEDStatus(nvmeSSD, configs[i], success, nvmeData);
+                    }
+                    else
+                    {
+                        setNvmeInventoryProperties(true, nvmeData, inventoryPath);
+                        iter->second->setSensorValueToDbus(nvmeData.sensorValue);
+
+                        iter->second->checkSensorThreshold();
+                        setSSDLEDStatus(iter->second, configs[i], success,
+                                        nvmeData);
+                    }
+                }
+                else
+                {
+                    // Present pin is true but power good pin is false
+                    // remove nvme d-bus path, clean all properties in inventory
+                    // and turn on fault LED
+                    std::cerr << "Present pin is true but power good pin is false. index = "<< std::to_string(configs[i].index) << std::endl;
+
+                    checkAssertFaultLED(
+                        configs[i].locateLedGroupPath,
+                        configs[i].faultLedGroupPath, true);
+                    checkAssertLocateLED(
+                        configs[i].locateLedGroupPath,
+                        configs[i].locateLedControllerBusName,
+                        configs[i].locateLedControllerPath, false);
+
+                    nvmeData = NVMeData();
+                    setNvmeInventoryProperties(false, nvmeData, inventoryPath);
+                    nvmes.erase(std::to_string(configs[i].index));
+                    std::cerr << "Erase SSD from map and d-bus. index = "<< std::to_string(configs[i].index) << std::endl;
+                }
+            }
+            else
+            {
+                // Drive not present, remove nvme d-bus path ,
+                // clean all properties in inventory
+                // and turn off fault and locate LED
+
+                checkAssertFaultLED(configs[i].locateLedGroupPath,
+                                            configs[i].faultLedGroupPath,
+                                            false);
+                checkAssertLocateLED(
+                    configs[i].locateLedGroupPath,
+                    configs[i].locateLedControllerBusName,
+                    configs[i].locateLedControllerPath, false);
+
+                nvmeData = NVMeData();
+                setNvmeInventoryProperties(false, nvmeData, inventoryPath);
+                nvmes.erase(std::to_string(configs[i].index));
+            }
+        }
+}
+} // namespace nvme
+} // namespace phosphor

--- a/nvme_manager.hpp
+++ b/nvme_manager.hpp
@@ -1,0 +1,100 @@
+#include "config.h"
+#include "nvmes.hpp"
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <sdeventplus/clock.hpp>
+#include <sdeventplus/event.hpp>
+#include <sdeventplus/utility/timer.hpp>
+
+namespace phosphor
+{
+namespace nvme
+{
+
+class Nvme
+{
+  public:
+    Nvme() = delete;
+    Nvme(const Nvme &) = delete;
+    Nvme &operator=(const Nvme &) = delete;
+    Nvme(Nvme &&) = delete;
+    Nvme &operator=(Nvme &&) = delete;
+
+    Nvme(sdbusplus::bus::bus &bus, const char *objPath) : bus(bus), _event(sdeventplus::Event::get_default()), _timer(_event, std::bind(&Nvme::read, this)), _objPath(objPath)
+    {
+    }
+
+    struct NVMeConfig
+    {
+        uint8_t index;
+        uint8_t busID;
+        std::string faultLedGroupPath;
+        uint8_t presentPin;
+        uint8_t pwrGoodPin;
+        std::string locateLedControllerBusName;
+        std::string locateLedControllerPath;
+        std::string locateLedGroupPath;
+        uint64_t criticalHigh;
+        uint64_t criticalLow;
+        uint64_t maxValue;
+        uint64_t minValue;
+    };
+
+    struct NVMeData {
+      bool present; /* Whether or not the nvme is present  */
+      std::string vendor; /* The nvme manufacturer  */
+      std::string serialNumber; /* The nvme serial number  */
+      std::string smartWarnings; /* Indicates smart warnings for the state  */
+      std::string statusFlags; /* Indicates the status of the drives  */
+      std::string driveLifeUsed; /* A vendor specific estimate of the percentage  */
+      u_int64_t sensorValue;/* Sensor value, if sensor value didn't be update, means sensor failure,
+                               default set to 129(0x81) accroding to NVMe-MI SPEC*/
+    };
+
+    void run();
+    const std::string _objPath;
+
+    std::string getValue(std::string);
+    std::unordered_map<std::string, std::shared_ptr<phosphor::nvme::NvmeSSD>>
+        nvmes;
+    void setSSDLEDStatus(std::shared_ptr<phosphor::nvme::NvmeSSD> nvmeSSD,
+                         phosphor::nvme::Nvme::NVMeConfig config, bool success,
+                         phosphor::nvme::Nvme::NVMeData nvmeData);
+
+    template <typename T>
+    void setFaultLED(const std::string &property, const T &value,
+                     std::string &ledPath);
+
+    template <typename T>
+    void setLocateLED(const std::string &property, const T &value,
+                      std::string &locateLedBusName,
+                      std::string &locateLedPath);
+
+    void checkAssertFaultLED(std::string &locateLedGroupPath,
+                             std::string &ledPath, bool request);
+    void checkAssertLocateLED(std::string &ledPath,
+                              std::string &locateLedBusName,
+                              std::string &locateLedPath, bool ispresent);
+
+    bool getLEDGroupState(std::string &ledPath);
+
+    template <typename T>
+    void setInventoryParm(std::string &objPath, const std::string &interface, const std::string &property, const T &value);
+
+    void setNvmeInventoryProperties(bool present, phosphor::nvme::Nvme::NVMeData nvmeData, std::string inventoryPath);
+    void assertFaultLog(int smartWarning, std::string inventoryPath);
+
+  private:
+    sdbusplus::bus::bus &bus;
+
+    sdeventplus::Event _event;
+    /** @brief Read Timer */
+    sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> _timer;
+
+    void init();
+    void read();
+
+};
+} // namespace nvme
+} // namespace phosphor

--- a/nvmes.cpp
+++ b/nvmes.cpp
@@ -1,0 +1,49 @@
+#include "nvme_manager.hpp"
+#include <iostream>
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/log.hpp>
+#include <sstream>
+#include <string>
+
+
+namespace phosphor
+{
+namespace nvme
+{
+using namespace std;
+using namespace phosphor::logging;
+
+void NvmeSSD::checkSensorThreshold()
+{
+    uint64_t value = ValueIface::value();
+    uint64_t criticalHigh = CriticalInterface::criticalHigh();
+    uint64_t criticalLow = CriticalInterface::criticalLow();
+
+    if (value > criticalHigh)
+        CriticalInterface::criticalAlarmHigh(true);
+    else
+        CriticalInterface::criticalAlarmHigh(false);
+
+    if (value < criticalLow)
+        CriticalInterface::criticalAlarmLow(true);
+    else
+        CriticalInterface::criticalAlarmLow(false);
+}
+
+void NvmeSSD::setSensorThreshold(uint64_t criticalHigh, uint64_t criticalLow,
+                                 uint64_t maxValue, uint64_t minValue)
+{
+
+    CriticalInterface::criticalHigh(criticalHigh);
+    CriticalInterface::criticalLow(criticalLow);
+    ValueIface::maxValue(maxValue);
+    ValueIface::minValue(minValue);
+}
+
+void NvmeSSD::setSensorValueToDbus(const u_int64_t value)
+{
+    ValueIface::value(value);
+}
+
+} // namespace nvme
+} // namespace phosphor

--- a/nvmes.hpp
+++ b/nvmes.hpp
@@ -1,0 +1,54 @@
+#include "config.h"
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server.hpp>
+#include <sdeventplus/clock.hpp>
+#include <sdeventplus/event.hpp>
+#include <sdeventplus/utility/timer.hpp>
+#include <xyz/openbmc_project/Inventory/Decorator/Asset/server.hpp>
+#include <xyz/openbmc_project/Inventory/Item/server.hpp>
+#include <xyz/openbmc_project/Nvme/Status/server.hpp>
+#include <xyz/openbmc_project/Sensor/Threshold/Critical/server.hpp>
+#include <xyz/openbmc_project/Sensor/Threshold/Warning/server.hpp>
+#include <xyz/openbmc_project/Sensor/Value/server.hpp>
+
+namespace phosphor
+{
+namespace nvme
+{
+
+using ValueIface = sdbusplus::xyz::openbmc_project::Sensor::server::Value;
+
+using CriticalInterface =
+    sdbusplus::xyz::openbmc_project::Sensor::Threshold::server::Critical;
+
+using WarningInterface =
+    sdbusplus::xyz::openbmc_project::Sensor::Threshold::server::Warning;
+
+using NvmeIfaces =
+    sdbusplus::server::object::object<ValueIface, CriticalInterface, WarningInterface>;
+
+class NvmeSSD : public NvmeIfaces
+{
+  public:
+    NvmeSSD() = delete;
+    NvmeSSD(const NvmeSSD &) = delete;
+    NvmeSSD &operator=(const NvmeSSD &) = delete;
+    NvmeSSD(NvmeSSD &&) = delete;
+    NvmeSSD &operator=(NvmeSSD &&) = delete;
+    virtual ~NvmeSSD() = default;
+
+    NvmeSSD(sdbusplus::bus::bus &bus, const char *objPath) :
+        NvmeIfaces(bus, objPath), bus(bus)
+    {
+    }
+
+    void setSensorValueToDbus(const u_int64_t value);
+    void checkSensorThreshold();
+    void setSensorThreshold(uint64_t criticalHigh, uint64_t criticalLow,
+                            uint64_t maxValue, uint64_t minValue);
+
+  private:
+    sdbusplus::bus::bus &bus;
+};
+} // namespace nvme
+} // namespace phosphor

--- a/smbus.cpp
+++ b/smbus.cpp
@@ -1,0 +1,514 @@
+/*
+    i2c-dev.h - i2c-bus driver, char device interface
+
+    Copyright (C) 1995-97 Simon G. Vogl
+    Copyright (C) 1998-99 Frodo Looijaard <frodol@dds.nl>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA 02110-1301 USA.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include "i2c-dev.h"
+#include "smbus.hpp"
+#include <iostream>
+
+#include <mutex>
+
+#define SMBUS_PEC     1
+
+/* Transaction Error code */
+#define ERR_SMBUS_BLOCK_WRITE    1
+#define ERR_SMBUS_BLOCK_READ     2
+#define ERR_SEQ_DISMATCH         3
+
+#define MAX_I2C_BUS             30
+
+
+
+static int fd[MAX_I2C_BUS] = {0};
+
+// #define printf(format, args...)  {}
+
+namespace phosphor
+{
+namespace smbus
+{
+
+std::mutex gMutex;
+
+
+void phosphor::smbus::Smbus::dump_hex(char *outbuf, int len)
+{
+    int i, j;
+
+    printf("\r\n--------------------------------------------------------------------------------\r\n");
+
+    for (i = 0; i < len; i+= 16)
+    {
+        printf("%4x char ", i);
+
+        for (j = 0; j < 16; j++)
+        {
+            unsigned char x = outbuf[i+j];
+
+            if (x < 32 || x > 126)
+                x = '.';
+
+            if ((i+j) >= len)
+                break;
+
+            printf("%c", x);
+        }
+
+        printf("%*s hex", 16-j, "");
+
+        for (j = 0; j < 16; j++)
+        {
+            if ((i+j) >= len)
+                break;
+
+            printf(" %02x", (unsigned char)outbuf[i+j]);
+        }
+
+        printf("\r\n");
+    }
+
+    printf("--------------------------------------------------------------------------------\n");
+}
+
+
+int phosphor::smbus::Smbus::open_i2c_dev(int i2cbus, char *filename, size_t size, int quiet)
+{
+    int file;
+
+    snprintf(filename, size, "/dev/i2c/%d", i2cbus);
+    filename[size - 1] = '\0';
+    file = open(filename, O_RDWR);
+
+    if (file < 0 && (errno == ENOENT || errno == ENOTDIR)) {
+        sprintf(filename, "/dev/i2c-%d", i2cbus);
+        file = open(filename, O_RDWR);
+    }
+
+    if (file < 0 && !quiet) {
+        if (errno == ENOENT) {
+            fprintf(stderr, "Error: Could not open file "
+                "`/dev/i2c-%d' or `/dev/i2c/%d': %s\n",
+                i2cbus, i2cbus, strerror(ENOENT));
+        } else {
+            fprintf(stderr, "Error: Could not open file "
+                "`%s': %s\n", filename, strerror(errno));
+            if (errno == EACCES)
+                fprintf(stderr, "Run as root?\n");
+        }
+    }
+
+    return file;
+}
+
+int phosphor::smbus::Smbus::set_slave_addr(int file, int address, int force)
+{
+    /* With force, let the user read from/write to the registers
+       even when a driver is also running */
+    if (ioctl(file, force ? I2C_SLAVE_FORCE : I2C_SLAVE, address) < 0) {
+        fprintf(stderr,
+            "Error: Could not set address to 0x%02x: %s\n",
+            address, strerror(errno));
+        return -errno;
+    }
+
+    return 0;
+}
+
+int phosphor::smbus::Smbus::smbus_block_write(int fd, uint8_t cmd, size_t data_len, uint8_t *data)
+{
+    int res;
+
+    /* Set PEC */
+    if (ioctl(fd, I2C_PEC, 1) < 0) {
+        fprintf(stderr, "Error: Could not set PEC: %s\n", strerror(errno));
+        return -errno;
+    }
+
+    /* Smbus block write */
+    res = i2c_smbus_write_block_data(fd, cmd, data_len, (__u8 *)data);
+    if(res < 0) {
+        fprintf(stderr, "Error: i2c_smbus_write_block_data failed\n");
+    }
+
+    /* clear PEC */
+    if (ioctl(fd, I2C_PEC, 0) < 0) {
+        fprintf(stderr, "Error: Could not clear PEC: %s\n", strerror(errno));
+        return -errno;
+    }
+
+    return res;
+}
+
+
+int phosphor::smbus::Smbus::smbusInit(int smbus_num)
+{
+    int res = 0;
+    char filename[20];
+
+    gMutex.lock();
+
+    fd[smbus_num] = open_i2c_dev(smbus_num, filename, sizeof(filename), 0);
+    if(fd[smbus_num] < 0) {
+        gMutex.unlock();
+
+        return -1;
+    }
+
+    //printf("\rSmbusInit: fd[smbus_num] = %d", fd[smbus_num]);
+    res =  fd[smbus_num];
+
+    gMutex.unlock();
+
+    return res;
+}
+
+void phosphor::smbus::Smbus::smbusClose(int smbus_num)
+{
+    close(fd[smbus_num]);
+}
+
+
+int phosphor::smbus::Smbus::SendSmbusCmd(int smbus_num, int8_t device_addr, uint8_t smbuscmd, char *rsp_data)
+{
+    int res, i, res_len;
+    char tmp[4];
+    unsigned char Rx_buf[I2C_DATA_MAX] = {0};
+
+    Rx_buf[0] = 1;
+    /* Smbus block read */
+
+    gMutex.lock();
+    res = i2c_read_after_write(fd[smbus_num], 0, device_addr, 1, (unsigned char *)&smbuscmd, I2C_DATA_MAX, 
+        (const unsigned char *)Rx_buf);
+    if(res < 0) {
+        fprintf(stderr, "Error: SendSmbusCmd failed\n");
+        //(smbus_num);
+        return -1;
+    }
+
+    res_len = Rx_buf[0]+1;
+
+    printf("Rx_buf:");
+    for(i = 0; i<res_len;i++)
+    {
+        printf("%02X", Rx_buf[i]);
+    }
+    printf("\n");
+
+     /* put rsp data */
+    for(i=0; i<res_len; i++) {
+        sprintf(tmp, " %02x", Rx_buf[i]);
+            strcat(rsp_data, tmp);
+    }
+    gMutex.unlock();
+
+    return res;
+}
+
+int phosphor::smbus::Smbus::GetSmbusCmdWord(int smbus_num, int8_t device_addr, int8_t smbuscmd )
+{
+    int res;
+
+    gMutex.lock();
+    if(fd[smbus_num] > 0) {
+        res = set_slave_addr(fd[smbus_num], device_addr, I2C_SLAVE);
+        if(res < 0) {
+            fprintf(stderr, "set PMBUS BUS%d to slave address 0x%02X failed (%s)\n", smbus_num, device_addr,strerror(errno));
+                close(fd[smbus_num]);
+                //(smbus_num);
+            return -1;
+        }
+    }
+
+    res = i2c_smbus_read_word_data(fd[smbus_num], smbuscmd);
+    if (res < 0) {
+        fprintf(stderr, "Error: Read failed\n");
+        gMutex.unlock();
+        return -1;
+    }
+
+    printf("\r[GetSmbusCmdWord] 0x%0*x",2, res);
+    //(smbus_num);
+    return res;
+}
+
+int phosphor::smbus::Smbus::SetSmbusCmdWord(int smbus_num, int8_t device_addr, int8_t smbuscmd , int16_t data)
+{
+    int res;
+
+    gMutex.lock();
+    if(fd[smbus_num] > 0) {
+        res = set_slave_addr(fd[smbus_num], device_addr, I2C_SLAVE);
+        if(res < 0) {
+            fprintf(stderr, "set PMBUS BUS%d to slave address 0x%02X failed (%s)\n", smbus_num, device_addr,strerror(errno));
+                close(fd[smbus_num]);
+
+                gMutex.unlock();
+            return -1;
+        }
+    }
+
+    res = i2c_smbus_write_word_data(fd[smbus_num], smbuscmd, data);
+    if (res < 0) {
+        fprintf(stderr, "Error: Read failed\n");
+        gMutex.unlock();
+
+        return -1;
+    }
+
+    printf("\r[GetSmbusCmdWord] 0x%0*x",2, res);
+    gMutex.unlock();
+    return res;
+}
+
+int phosphor::smbus::Smbus::GetSmbusCmdByte(int smbus_num, int8_t device_addr, int8_t smbuscmd)
+{
+    int res;
+
+    gMutex.lock();
+    if(fd[smbus_num] > 0) {
+        res = set_slave_addr(fd[smbus_num], device_addr, I2C_SLAVE);
+        if(res < 0) {
+            fprintf(stderr, "set PMBUS BUS%d to slave address 0x%02X failed (%s)\n", smbus_num, device_addr,strerror(errno));
+                close(fd[smbus_num]);
+
+                gMutex.unlock();
+            return -1;
+        }
+    }
+
+    res = i2c_smbus_read_byte_data(fd[smbus_num], smbuscmd);
+    if (res < 0) {
+        fprintf(stderr, "Error: Read failed\n");
+        gMutex.unlock();
+
+        return -1;
+    }
+    // printf("[GetSmbusCmdByte]0x%0*x\n",2, res);
+
+    gMutex.unlock();
+    return res;
+}
+
+int phosphor::smbus::Smbus::SetSmbusCmdByte(int smbus_num, int8_t device_addr, int8_t smbuscmd , int8_t data)
+{
+    int res;
+
+    gMutex.lock();
+    if(fd[smbus_num] > 0) {
+        res = set_slave_addr(fd[smbus_num], device_addr, I2C_SLAVE);
+        if(res < 0) {
+            fprintf(stderr, "set PMBUS BUS%d to slave address 0x%02X failed (%s)\n", smbus_num, device_addr,strerror(errno));
+                close(fd[smbus_num]);
+
+                gMutex.unlock();
+            return -1;
+        }
+    }
+
+    res = i2c_smbus_write_byte_data(fd[smbus_num], smbuscmd, data);
+    if (res < 0) {
+        fprintf(stderr, "Error: Read failed\n");
+        gMutex.unlock();
+
+        return -1;
+    }
+    // printf("[SetSmbusCmdByte]0x%0*x\n",2, res);
+
+    gMutex.unlock();
+    return res;
+}
+
+int phosphor::smbus::Smbus::SmbusCmdProcessCall(int smbus_num, int8_t device_addr, int8_t smbuscmd , int16_t smbusdata )
+{
+    int res;
+
+    gMutex.lock();
+    if(fd[smbus_num] > 0) {
+        res = set_slave_addr(fd[smbus_num], device_addr, I2C_SLAVE);
+        if(res < 0) {
+            fprintf(stderr, "set PMBUS BUS%d to slave address 0x%02X failed (%s)\n", smbus_num, device_addr,strerror(errno));
+                close(fd[smbus_num]);
+
+                gMutex.unlock();
+            return -1;
+        }
+    }
+
+    res = i2c_smbus_process_call(fd[smbus_num], smbuscmd , smbusdata);
+    if (res < 0) {
+        fprintf(stderr, "Error: Read failed\n");
+
+        gMutex.unlock();
+        return -1;
+    }
+    printf("\r[GetSmbusCmdProcessCall]0x%0*x",2, res);
+
+    gMutex.unlock();
+    return res;
+}
+
+
+int phosphor::smbus::Smbus::SendSmbusRWBlockCmd(int smbus_num, int8_t device_addr, uint8_t *tx_data,
+uint8_t tx_len, char *rsp_data)
+{
+    int res, i, res_len, tmp_tx_len = 3;
+    char tmp[4];
+    unsigned char Rx_buf[I2C_DATA_MAX] = {0};
+    unsigned char tmp_tx_buf[I2C_DATA_MAX] = {0};
+
+    Rx_buf[0] = 1;
+    /* Smbus block read */
+
+    gMutex.lock();
+    res = i2c_read_after_write(fd[smbus_num], 0, device_addr, tx_len, (unsigned char *)tx_data, I2C_DATA_MAX, 
+        (const unsigned char *)Rx_buf);
+
+    if(res < 0) {
+        fprintf(stderr, "Error: SendSmbusCmd failed\n");
+
+        gMutex.unlock();
+        return -1;
+    }
+
+    res_len = Rx_buf[0]+1;
+
+    // printf("Rx_buf:");
+    // for(i = 0; i<res_len;i++)
+    // {
+    //     printf("%02X", Rx_buf[i]);
+    // }
+    // printf("\n");
+
+     /* put rsp data */
+    for(i=0; i<res_len; i++) {
+        sprintf(tmp, " %02x", Rx_buf[i]);
+            strcat(rsp_data, tmp);
+    }
+
+    gMutex.unlock();
+    return res;
+}
+
+int phosphor::smbus::Smbus::SendSmbusWBlockCmd(int smbus_num, int8_t device_addr , int8_t command, uint8_t *tx_data,
+uint8_t tx_len)
+{
+    int res, i, res_len, tmp_tx_len = 3;
+    char tmp[4];
+    unsigned char tmp_tx_buf[I2C_DATA_MAX] = {0};
+
+    gMutex.lock();
+    if(fd[smbus_num] > 0) {
+        res = set_slave_addr(fd[smbus_num], device_addr, I2C_SLAVE);
+        if(res < 0) {
+            fprintf(stderr, "set PMBUS BUS%d to slave address 0x%02X failed (%s)\n", smbus_num, device_addr,strerror(errno));
+                close(fd[smbus_num]);
+
+                gMutex.unlock();
+            return -1;
+        }
+    }
+
+    /* Set PEC */
+    if (ioctl(fd[smbus_num] , I2C_PEC, 1) < 0) {
+        fprintf(stderr, "Error: Could not set PEC: %s\n", strerror(errno));
+
+        gMutex.unlock();
+        return -errno;
+    }
+
+
+    res = i2c_smbus_write_block_data(fd[smbus_num], command, tx_len, (unsigned char *)tx_data);    
+
+    if(res < 0) {
+        fprintf(stderr, "Error: i2c_smbus_write_block_data failed\n");
+    }
+
+    /* clear PEC */
+    if (ioctl(fd[smbus_num], I2C_PEC, 0) < 0) {
+        fprintf(stderr, "Error: Could not clear PEC: %s\n", strerror(errno));
+
+        return -errno;
+    }
+
+    return res;
+}
+
+
+int phosphor::smbus::Smbus::SendSmbusWBlockByMasterWrite(int smbus_num, int8_t device_addr , int8_t command, uint8_t *tx_data,
+uint8_t tx_len)
+{
+    int res, i, res_len, tmp_tx_len = 3;
+    char tmp[4];
+    unsigned char tmp_tx_buf[I2C_DATA_MAX] = {0};
+
+    gMutex.lock();
+    res = i2c_master_write(fd[smbus_num],device_addr,tx_len,tx_data);
+
+    if(res < 0) {
+        fprintf(stderr, "Error: SendSmbusWBlockByMasterWrite failed\n");
+    }
+
+
+    gMutex.unlock();
+    return res;
+}
+
+
+int phosphor::smbus::Smbus::SendSmbusRWBlockCmdRAW(int smbus_num, int8_t device_addr, uint8_t *tx_data,
+uint8_t tx_len, uint8_t *rsp_data)
+{
+    int res, i, res_len, tmp_tx_len = 8;
+    char tmp[4];
+    unsigned char Rx_buf[I2C_DATA_MAX] = {0};
+    unsigned char tmp_tx_buf[I2C_DATA_MAX] = {0};
+
+    Rx_buf[0] = 1;
+
+    gMutex.lock();
+
+    res = i2c_read_after_write(fd[smbus_num], 0, device_addr, tx_len, (unsigned char *)tx_data, I2C_DATA_MAX, 
+        (const unsigned char *)Rx_buf);
+
+    if(res < 0) {
+        fprintf(stderr, "Error: SendSmbusRWBlockCmdRAW failed\n");
+    }
+
+    res_len = Rx_buf[0]+1;
+
+    memcpy(rsp_data,Rx_buf,res_len);
+
+    gMutex.unlock();
+
+    return res;
+}
+
+}
+}

--- a/smbus.hpp
+++ b/smbus.hpp
@@ -1,0 +1,62 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <errno.h>
+#include "i2c-dev.h"
+
+namespace phosphor
+{
+namespace smbus
+{
+
+
+    class Smbus
+    {
+        public:
+
+        Smbus(){};
+
+        void dump_hex(char *outbuf, int len);
+
+        int open_i2c_dev(int i2cbus, char *filename, size_t size, int quiet);
+
+        int set_slave_addr(int file, int address, int force);
+
+        int smbus_block_write(int fd, uint8_t cmd, size_t data_len, uint8_t *data);
+
+        int smbusInit(int smbus_num);
+
+        void smbusClose(int smbus_num);
+
+        int SendSmbusCmd(int smbus_num, int8_t device_addr, uint8_t smbuscmd, char *rsp_data);
+
+        int GetSmbusCmdWord(int smbus_num, int8_t device_addr, int8_t smbuscmd );
+
+        int SetSmbusCmdWord(int smbus_num, int8_t device_addr, int8_t smbuscmd , int16_t data);
+
+        int GetSmbusCmdByte(int smbus_num, int8_t device_addr, int8_t smbuscmd);
+
+        int SetSmbusCmdByte(int smbus_num, int8_t device_addr, int8_t smbuscmd , int8_t data);
+
+        int SmbusCmdProcessCall(int smbus_num, int8_t device_addr, int8_t smbuscmd , int16_t smbusdata );
+
+        int SendSmbusRWBlockCmd(int smbus_num, int8_t device_addr, uint8_t *tx_data,
+            uint8_t tx_len, char *rsp_data);
+
+        int SendSmbusWBlockCmd(int smbus_num, int8_t device_addr , int8_t command, uint8_t *tx_data,
+            uint8_t tx_len);
+
+        int SendSmbusWBlockByMasterWrite(int smbus_num, int8_t device_addr , int8_t command, uint8_t *tx_data,
+            uint8_t tx_len);
+
+        int SendSmbusRWBlockCmdRAW(int smbus_num, int8_t device_addr, uint8_t *tx_data,
+            uint8_t tx_len, uint8_t *rsp_data);
+    };
+
+}
+}


### PR DESCRIPTION
phosphor-nvme is the nvme manager service maintains
for NVMe drive information update and related notification
processing service.

Signed-off-by: Tony Lee <tony.lee@quantatw.com>
Change-Id: I32678dc4cf246d67b3bdc3329b5c3f70901f66c2